### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,9 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/omeritzics/Updatium/security/code-scanning/5](https://github.com/omeritzics/Updatium/security/code-scanning/5)

The best practice is to specify a `permissions` key at the earliest applicable scope. You can set it at the workflow root (top-level, affecting all jobs), or on each job (if some jobs require different permissions). According to the CodeQL message and the nature of the actions used, the minimal set is:

```yaml
permissions:
  contents: read
  security-events: write
```

The `contents: read` allows for code checkout, and `security-events: write` grants the minimum required for uploading SARIF files to the Security tab with `github/codeql-action/upload-sarif`. 

You should insert this `permissions` block at the top level, after the `name:` and before the `on:` block, for maximum clarity and coverage. No further code or configuration is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
