### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,4 +1,6 @@
 name: Android CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/omeritzics/Updatium/security/code-scanning/4](https://github.com/omeritzics/Updatium/security/code-scanning/4)

To fix this problem, you should add a `permissions` key to the workflow to explicitly specify which permissions the workflow has, reducing the risk of granting excess privileges. The most restrictive and generally safe value for a build/test workflow is `contents: read`, unless there are steps that require more access. The best way to do this is to add the following at the top-level of the workflow file, just under the `name` block and before the `on:` trigger, or directly as the first key in the workflow configuration. No existing functionality will be changed.

- **Location:** At the root/top-level, right after `name: Android CI`.
- **Change:** Insert a permissions block with `contents: read`.
- **Methods/imports:** No additional packages or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
