### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -4,6 +4,8 @@
 # documentation.
 
 name: Dart
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/omeritzics/Updatium/security/code-scanning/1](https://github.com/omeritzics/Updatium/security/code-scanning/1)

To fix the problem, add a `permissions` block at the top level of the workflow file, just after the `name:` and before the `on:` key. This limits the default GITHUB_TOKEN permissions for all jobs in this workflow to read-only on repository contents, following the principle of least privilege. No existing functionality will be affected, as none of the jobs in this workflow require additional permissions (they simply check out code, install dependencies, analyze, and test).

You only need to add the following block:

```yaml
permissions:
  contents: read
```

Insert it after line 6 (`name: Dart`) and before line 8 (`on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
