### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Build and Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/omeritzics/Updatium/security/code-scanning/2](https://github.com/omeritzics/Updatium/security/code-scanning/2)

To fix the problem, explicitly specify a `permissions` block at the top level of the workflow (root scope), applying least-privilege settings. The minimal starting point is `contents: read`, which allows read-only access to repository contents. However, this workflow needs to be reviewed for steps requiring higher privileges. In this file, the steps that will require extra permissions are:

- `mathieudutour/github-tag-action@v6.1` (creates tags): needs `contents: write`.
- `ncipollo/release-action@v1` (creates draft releases): also needs `contents: write`.

To avoid workflow failure, the correct least-privilege block at the workflow root is:
```yaml
permissions:
  contents: write
```
Add this right after the workflow `name`, before the `on:` block.

Only edit `.github/workflows/release.yml`. No imports or other file changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
