### PR TITLE
Revert "chore(deps): update plugin org.jetbrains.kotlin.android to v2.3.0"

### DIFF
--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.13.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.3.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Reverts omeritzics/Updatium#42

## Summary by Sourcery

Build:
- Downgrade the org.jetbrains.kotlin.android Gradle plugin from 2.3.0 to 2.2.20 in android/settings.gradle.kts.