### PR TITLE
Fix remaining syntax errors in apps.dart

### DIFF
--- a/lib/pages/apps.dart
+++ b/lib/pages/apps.dart
@@ -193,10 +193,11 @@ class AppsPageState extends State<AppsPage> {
       showError(e is Map ? e['errors'] : e, context);
       return <App>[];
     } finally {
-      if (!mounted) return;
-      setState(() {
-        refreshingSince = null;
-      });
+      if (mounted) {
+        setState(() {
+          refreshingSince = null;
+        });
+      }
     }
   }
 
@@ -881,7 +882,8 @@ class AppsPageState extends State<AppsPage> {
                         ).textTheme.bodySmall?.copyWith(fontSize: 11),
                       ),
                     ),
-                    const SizedBox(height: 12),
+                  ),
+                  const SizedBox(height: 12),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 12.0),
                       child: Builder(


### PR DESCRIPTION
### **User description**
- Add missing closing bracket for Flexible widget
- Fix async function return issue in refresh() method
- Resolve bracket mismatches and structural issues
- Ensure proper widget nesting and closure


___

### **PR Type**
Bug fix


___

### **Description**
- Fix early return preventing state updates in refresh() method

- Correct widget nesting by closing Padding widget properly

- Ensure setState() only executes when widget is mounted


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["refresh() method"] -->|"early return issue"| B["State not updated"]
  C["Fix: check mounted first"] -->|"wrap setState"| D["Proper state update"]
  E["Widget nesting error"] -->|"missing close paren"| F["Syntax error"]
  G["Fix: close Padding"] -->|"correct structure"| H["Valid widget tree"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apps.dart</strong><dd><code>Fix state updates and widget nesting errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/pages/apps.dart

<ul><li>Fixed early return in refresh() method by inverting condition to check <br>if mounted before setState<br> <li> Corrected widget nesting by adding missing closing parenthesis for <br>Padding widget<br> <li> Improved code safety by ensuring setState() is only called when widget <br>is mounted</ul>


</details>


  </td>
  <td><a href="https://github.com/omeritzics/Updatium/pull/144/files#diff-2df55bb316de7a6e88747f4ba268687071570ba6a24c864e099edbef4da275d8">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

